### PR TITLE
Fixed scrolling bug

### DIFF
--- a/Car/src/activity/messages/messages-activity/chat/Chat.tsx
+++ b/Car/src/activity/messages/messages-activity/chat/Chat.tsx
@@ -331,7 +331,6 @@ const Chat = (properties: ChatProps) => {
                 return onlyUniqueMessages(temp.sort((a, b) => Number(b._id) - Number(a._id)));
             });
             setLoadingNewer(false);
-            focusOnMessage(firstMessage);
         });
     };
 


### PR DESCRIPTION
Now when user scroll up to the beginning of chat, you are not tilted to the end of chat