### PR TITLE
Closed #971 - Added Canceled and Requested journeys to All tab

### DIFF
--- a/Car/__tests__/activity/journey/JourneyStartPage-test.tsx
+++ b/Car/__tests__/activity/journey/JourneyStartPage-test.tsx
@@ -389,6 +389,12 @@ test("renders correctly", async () =>
           <JourneyCardList
             journey={Array []}
           />
+          <RequestCardList
+            request={Array []}
+          />
+          <JourneyCardList
+            journey={Array []}
+          />
         </View>
       </View>
     </ScrollView>

--- a/Car/src/activity/journey/JourneyStartPage.tsx
+++ b/Car/src/activity/journey/JourneyStartPage.tsx
@@ -317,6 +317,18 @@ const JourneyStartPage = (props: NavigationAddListener) => {
                             </Text>
                         )}
                         {<JourneyCardList journey={scheduledJourneys} />}
+                        {requestedJourneys.length > EMPTY_COLLECTION_LENGTH && (
+                            <Text style={[JourneyStartPageStyle.tabTextStyle, { color: colors.primary }]}>
+                                Requested
+                            </Text>
+                        )}
+                        {<RequestCardList request={requestedJourneys} />}
+                        {canceledJourneys.length > EMPTY_COLLECTION_LENGTH && (
+                            <Text style={[JourneyStartPageStyle.tabTextStyle, { color: colors.primary }]}>
+                                Canceled
+                            </Text>
+                        )}
+                        {<JourneyCardList journey={canceledJourneys} />}
                     </View>
                 )}
                 {selectedIndex === SECOND_ELEMENT_INDEX && (


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [x] @Pumpumpumbrr

### Second Level Review

- [x] @Waldemier 

## Summary of issue

[Canceled and Requested journeys were not displayed on All tab
](https://github.com/ita-social-projects/Car-Back-End/issues/971)

## Summary of change

Added views of Canceled and Requested journeys

## Testing approach

Tested on AVD
![image](https://user-images.githubusercontent.com/88668437/150594000-a4c3f879-9301-4a17-86b7-6821b460c790.png)

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
