### PR TITLE
Fixed #978 [Ride Invitations page] Long e-mail addresses are overlapped with the 'Close' button in the e-mail edit box and 'New invitations' header does not correspond to the mock-up.

### DIFF
--- a/Car/src/activity/journey/journey-activity/create-journey/CreateJourneyStyle.tsx
+++ b/Car/src/activity/journey/journey-activity/create-journey/CreateJourneyStyle.tsx
@@ -72,6 +72,7 @@ export const CreateJourneyStyle = StyleSheet.create({
         borderWidth: 1,
         fontSize: 15,
         paddingLeft: 10,
+        paddingRight: '12%',
     },
 
     commentsCaption: {

--- a/Car/src/activity/journey/journey-activity/journey-invitations/JourneyInvitationsPage.tsx
+++ b/Car/src/activity/journey/journey-activity/journey-invitations/JourneyInvitationsPage.tsx
@@ -95,7 +95,7 @@ const JourneyInvitationsPage = (props: JourneyInvitationsPageProps) => {
                 }
 
                 <View style={CreateJourneyStyle.commentsView}>
-                    <Text style={[CreateJourneyStyle.commentsCaption, { color: colors.primary }]}>New invitations</Text>
+                    <Text style={[CreateJourneyStyle.commentsCaption, { color: colors.primary }]}>New invitation</Text>
                     {invitedUsers.map((us, index) => (
                         <View key={index}>
                             <TextInput


### PR DESCRIPTION
/ita-social-projects/Car-Back-End/issues/978