### PR TITLE
Fixed #989 [Ride Homepage] Canceled rides are not accessible to be opened by tapping any of them.

### DIFF
--- a/Car/__tests__/activity/journey/JourneyPage-test.tsx
+++ b/Car/__tests__/activity/journey/JourneyPage-test.tsx
@@ -15,7 +15,8 @@ const props: JourneyPageProps = {
             isDriver: false,
             isPassenger: false,
             applicantStops: [],
-            isPast: false
+            isPast: false,
+            isCanceled: false
         },
     },
     moreOptionsPopupIsOpen: false,

--- a/Car/__tests__/activity/journey/JourneyStartPage-test.tsx
+++ b/Car/__tests__/activity/journey/JourneyStartPage-test.tsx
@@ -387,6 +387,7 @@ test("renders correctly", async () =>
             request={Array []}
           />
           <JourneyCardList
+            isCanceled={true}
             journey={Array []}
           />
         </View>

--- a/Car/__tests__/activity/journey/OkSearchResult-test.tsx
+++ b/Car/__tests__/activity/journey/OkSearchResult-test.tsx
@@ -12,6 +12,7 @@ const props: OkSearchResultProps = {
             displayFee: false,
             passangersCount: 1,
             isPast: false,
+            isCanceled: false
         },
     },
 };

--- a/Car/__tests__/components/JourneyCard-test.tsx
+++ b/Car/__tests__/components/JourneyCard-test.tsx
@@ -5,7 +5,7 @@ import JourneyCard from "../../src/components/journey-card/JourneyCard";
 const renderer = shallowRender.createRenderer();
 
 test("renders correctly", async () =>
-    expect(renderer.render(<JourneyCard isPast={false} />))
+    expect(renderer.render(<JourneyCard isPast={false} isCanceled={false} />))
         .toMatchInlineSnapshot(`
     <View>
       <ForwardRef

--- a/Car/src/activity/journey/JourneyStartPage.tsx
+++ b/Car/src/activity/journey/JourneyStartPage.tsx
@@ -329,7 +329,7 @@ const JourneyStartPage = (props: NavigationAddListener) => {
                                 Canceled
                             </Text>
                         )}
-                        {<JourneyCardList journey={canceledJourneys} />}
+                        {<JourneyCardList journey={canceledJourneys} isCanceled={true}/>}
                     </View>
                 )}
                 {selectedIndex === SECOND_ELEMENT_INDEX && (
@@ -354,7 +354,7 @@ const JourneyStartPage = (props: NavigationAddListener) => {
                 )}
                 {selectedIndex === SIXTH_ELEMENT_INDEX && (
                     <View style={JourneyStartPageStyle.tabStyle}>
-                        {<JourneyCardList journey={canceledJourneys} />}
+                        {<JourneyCardList journey={canceledJourneys} isCanceled={true}/>}
                     </View>
                 )}
             </View>

--- a/Car/src/activity/journey/journey-activity/journey-page/JourneyPage.tsx
+++ b/Car/src/activity/journey/journey-activity/journey-page/JourneyPage.tsx
@@ -77,6 +77,7 @@ const JourneyPage: JourneyPageComponent = ({ props }: { props: JourneyPageProps 
     const { isDriver } = props.route.params;
     const { isPassenger } = props.route.params;
     const { isPast } = props.route.params;
+    const { isCanceled } = props.route.params;
     const [isLoading, setLoading] = useState(true);
     const [car, setCar] = useState<CarViewModel>(null);
     const [isRequested, setRequested] = useState(false);
@@ -104,7 +105,7 @@ const JourneyPage: JourneyPageComponent = ({ props }: { props: JourneyPageProps 
     const applicantStops = props.route.params.applicantStops;
 
     const onFocusHandler = () => {
-        JourneyService.getJourney(journeyId).then((res) => {
+        JourneyService.getJourney(journeyId, isCanceled).then((res) => {
             setJourney(res.data);
             mapRef.current?.fitToCoordinates(res.data?.journeyPoints,
                 { edgePadding: { top: 20, right: 20, left: 20, bottom: 800 } });

--- a/Car/src/activity/journey/journey-activity/journey-page/JourneyPageProps.tsx
+++ b/Car/src/activity/journey/journey-activity/journey-page/JourneyPageProps.tsx
@@ -8,7 +8,8 @@ interface JourneyPageProps {
             isPassenger: boolean,
             applicantStops?: Stop[],
             passangersCount?: number,
-            isPast: boolean
+            isPast: boolean,
+            isCanceled: boolean
         }
     },
     navigation?: {

--- a/Car/src/activity/journey/journey-activity/search-journey/search-results/ok-search-result/OkSearchResult.tsx
+++ b/Car/src/activity/journey/journey-activity/search-journey/search-results/ok-search-result/OkSearchResult.tsx
@@ -85,6 +85,7 @@ const OkSearchResult = (props: OkSearchResultProps) => {
                             applicantStops={item.applicantStops}
                             passangersCount={props.route.params.passangersCount}
                             isPast={props.route.params.isPast}
+                            isCanceled={props.route.params.isCanceled}
                         />
                     )}
                 />

--- a/Car/src/activity/journey/journey-activity/search-journey/search-results/ok-search-result/OkSearchResultProps.tsx
+++ b/Car/src/activity/journey/journey-activity/search-journey/search-results/ok-search-result/OkSearchResultProps.tsx
@@ -7,7 +7,8 @@ interface OkSearchResultProps
             journeys: ApplicantJourney[],
             displayFee: boolean,
             passangersCount: number,
-            isPast: boolean
+            isPast: boolean,
+            isCanceled: boolean
         }
     }
 }

--- a/Car/src/components/journey-card/JourneyCard.tsx
+++ b/Car/src/components/journey-card/JourneyCard.tsx
@@ -20,7 +20,8 @@ const JourneyCard =
         displayFee?: boolean,
         applicantStops?: Stop[],
         passangersCount?: number,
-        isPast: boolean
+        isPast: boolean,
+        isCanceled: boolean
             }) => {
         const { colors } = useTheme();
         const journey = props.journey;
@@ -41,7 +42,8 @@ const JourneyCard =
                 isPassenger,
                 applicantStops: props.applicantStops,
                 passangersCount: props.passangersCount,
-                isPast: props.isPast
+                isPast: props.isPast,
+                isCanceled: props.isCanceled
             });
 
         const fullName = `${journey?.organizer?.name} ${journey?.organizer?.surname}`;

--- a/Car/src/components/journey-card/JourneyCardList.tsx
+++ b/Car/src/components/journey-card/JourneyCardList.tsx
@@ -7,12 +7,14 @@ import JourneyCard from "./JourneyCard";
 interface JourneyCardListProps {
     journey: Journey[],
     ascending?: boolean,
-    isPast?: boolean
+    isPast?: boolean,
+    isCanceled?: boolean
 }
 
 const JourneyCardList = (props:JourneyCardListProps) => {
     const journey: Journey[] = props.journey;
     const isPast: boolean = props.isPast ?? false;
+    const isCanceled: boolean = props.isCanceled ?? false;
 
     journey.sort((a: Journey, b: Journey) => compare(a,b, props.ascending));
 
@@ -31,7 +33,7 @@ const JourneyCardList = (props:JourneyCardListProps) => {
         <View>
             {journey.map((item) => (
                 <View key={item?.id}>
-                    <JourneyCard journey={item} displayFee={true} isPast={isPast}/>
+                    <JourneyCard journey={item} displayFee={true} isPast={isPast} isCanceled={isCanceled}/>
                 </View>
             ))}
         </View>


### PR DESCRIPTION
/ita-social-projects/Car-Back-End/issues/989