### PR TITLE
[Footer] The number of unread messages shown near the Chat icon is colored incorrectly.

### DIFF
--- a/Car/src/components/navigation/app-tabs/AppTabs.tsx
+++ b/Car/src/components/navigation/app-tabs/AppTabs.tsx
@@ -117,7 +117,7 @@ const AppTabs = () => {
                 options={() => ({
                     tabBarLabel: "Chats",
                     tabBarBadge : tabBarUnreadMessages,
-                    tabBarBadgeStyle: { backgroundColor: "#fcba03", color: "#ffffff" }
+                    tabBarBadgeStyle: { backgroundColor: "#EC6400", color: "#ffffff" }
                 })}
             />
             <Tabs.Screen


### PR DESCRIPTION
/ita-social-projects/Car-Back-End/issues/1050